### PR TITLE
add total reads to voucher collection file

### DIFF
--- a/CollectionData/plant_voucher_collection.csv
+++ b/CollectionData/plant_voucher_collection.csv
@@ -1,130 +1,130 @@
-year,month,day,season,sp_code,sci_name_fieldID,sci_name_profID,voucher,DNA,label_number,collector,location,easting,northing,elevation (m),vial_barcode,notes
-2017,1,26,,,,,,,millet,,,,,,S009063,bait
-2016,3,20,winter,cass bauh,Cassia bauhinoides,Senna bauhinoides,Y,Y,SKME_001,EKB,ramada,681200.79,3535287.25,1315,S009007,
-2016,3,20,winter,spha hast,Sphaeralcea coccinea,Sphaeralcea hastulata,Y,Y,SKME_002,EKB,"Plot 23, stake 65",681706.89,3535024.91,1315,S009904,
-2016,3,20,winter,amsi tess,Amsinckia tessellata,Amsinckia tessellata,Y,Y,SKME_003,EKB,"Plot 22, stake 67",681645.78,3534990.26,1316,S009037,
-2016,3,20,winter,micr lene,Uropappus lindleyi,Uropappus lindleyi,Y,Y,SKME_004,EKB,"Plot 22, stake 35",681631.8,3535006.72,1316,S009099,
-2016,3,20,winter,erig conc,Erigeron concinnus,Erigeron concinnus,Y,Y,SKME_005,EKB,"Plot 22, stake 53",681620.44,3534994.09,1316,S009016,
-2016,3,20,winter,atri cane,Atriplex canescens,Atriplex canescens,Y,Y,SKME_006,EKB,"Plot 20, stake 31",681459.32,3534993.28,1319,S008895,
-2016,3,20,winter,euro lana,Eurotia lanata,Krascheninnikovia lanata,Y,Y,SKME_007,EKB,"Plot 13, stake 75",681254.99,3535039.18,1322,S009001,
-2016,3,20,winter,pros glan,Prosopis glandulosa,Prosopis glandulosa,Y,Y,SKME_008,EKB,"Plot 13, stake 72",681236.34,3535038.21,1322,S009006,
-2016,3,20,winter,phac ariz,Phacelia arizonica,Phacelia arizonica,Y,Y,SKME_009,EKB,ramada,681200.79,3535287.25,1315,S008897,
-2016,3,20,winter,lupi conc,Lupinus concinnus,Lupinus concinnus,Y,Y,SKME_010,EKB,ramada,681200.79,3535287.25,1315,S009017,
-2016,3,20,winter,chen frem,Chenopodium fremontii,Chenopodium fremontii,Y,Y,SKME_011,EKB,ramada,681200.79,3535287.25,1315,S008870,
-2016,3,20,winter,desc pinn,Descurainia pinnata,Descurainia pinnata,Y,Y,SKME_012,EKB,ramada,681200.79,3535287.25,1315,S009010,
-2016,3,20,winter,guti saro,Gutierrezia sarothrae,Gutierrezia microcephala,Y,Y,SKME_013,EKB,ramada,681200.79,3535287.25,1315,S009013,
-2016,3,23,winter,mala fend,Malacothrix fendleri,Malacothrix fendleri,Y,Y,SKME_014,SDT,ramada,681200.79,3535287.25,1315,S009003,
-2016,3,23,winter,plan purs,Plantago patagonica,Plantago patagonica,Y,Y,SKME_015,EKB,far entrance,681231.07,3535279.78,1315,S009027,
-2016,3,23,winter,crot cory,Croton pottsii,Croton pottsii,Y,Y,SKME_016,EKB,far entrance,681231.07,3535279.78,1315,S008809,
-2016,3,23,winter,erig conc,Erigeron divergens,Erigeron concinnus,Y,Y,SKME_017,EKB,"Plot 1, stake 43",681219.91,3535262.79,1321,S008885,
-2016,3,23,winter,erio aber,Eriogonum abertianum,Eriogonum abertianum,Y,Y,SKME_018,EKB,"Plot 1, stake 13",681219.36,3535279.6,1321,S008864,
-2016,3,23,winter,hoff dens,Hoffmanseggia densiflora,Hoffmannseggia glauca,Y,Y,SKME_019,SDT,"Plot 1, stake 13",681219.89,3535281.58,1321,S008818,
-2016,3,23,winter,lepi lasi,Lepidium lasiocarpum,Lepidium lasiocarpum,Y,Y,SKME_020,SDT,"Plot 1, stake 17",681244.22,3535281.57,1321,S009057,
-2016,3,23,winter,astr allo,Astragalus allochrous,Astragalus allochrous,Y,Y,SKME_021,EKB,"Plot 2, stake 12",681288.65,3535283.03,1320,S008874,
-2016,3,23,winter,chae stev,Chaenactis stevioides,Chaenactis stevioides,Y,Y,SKME_022,EKB,Plot 1,681225.98,3535262.99,1321,S009098,
-2016,3,23,winter,erod cicu,Erodium cicutarium,Erodium cicutarium,Y,Y,SKME_023,EKB,Plot 1,681225.98,3535262.99,1321,S009011,
-2016,3,23,winter,pere nana,Perezia nana,Perezia nana,Y,Y,SKME_024,EKB,between Plots 2 and 3,681350,3535275,1320,S009012,
-2016,3,23,winter,dich pulc,Dichelostemma pulchellum,Dichelostemma pulchellum,Y,Y,SKME_025,EKB,"Plot 2, SE corner",681326.62,3535240.94,1320,S008866,
-2016,3,23,winter,sper echi,Spermolepis echinata,Spermolepis echinata,Y,Y,SKME_026,EKB,"Plot 2, SW corner",681276.31,3535288.84,1320,S009002,
-2016,3,23,winter,lapp redo,Lappula redowskii,Lappula redowskii,Y,Y,SKME_027,SKME,"Plot 2, N side",681301,3535283.44,1320,S009089,
-2016,3,23,winter,lesq gord,Lesquerella gordonii,Physaria gordonii,Y,Y,SKME_028,SKME,"Plot 3, stake 32",681363.26,3535273.13,1318,S008887,
-2016,3,23,winter,esch mexi,Eschscholzia californica,Eschscholzia californica,Y,Y,SKME_029,SDT,W of Plot 3,681357.08,3535260.79,1318,S009005,
-2016,3,23,winter,dale pogo,Dalea pogonathera,Dalea pogonathera,Y,Y,SKME_030,EKB,"Plot 3, stake 36",681387.98,3535274.16,1318,S009088,
-2016,3,23,winter,delp woot,Delphinium wootonii,Delphinium wootonii,N,Y,SKME_031,EKB,"Plot 3, stake 31",681356.75,3535272.74,1318,S008876,
-2016,3,23,winter,bail mult,Baileya multiradiata,Baileya multiradiata,Y,Y,SKME_032,SDT,"Plot 4, stake 51",681432.77,3535262.24,1317,S008892,
-2016,3,23,winter,chae eric,Chaetopappa ericoides,Chaetopappa ericoides,Y,Y,SKME_033,SDT,"Plot 6, stake 15",681608.23,3535310.21,1314,S008880,
-2016,3,23,winter,eria diff,Eriastrum diffusum,Eriastrum diffusum,Y,Y,SKME_034,SDT,ramada,681200.79,3535287.25,1315,S009014,
-2016,3,23,winter,sola elea,Solanum elaeagnifolium,Solanum elaeagnifolium,Y,Y,SKME_035,EKB,N of Plot 14,681323.33,3535080.38,1321,S008893,
-2016,3,23,winter,flou cern,Flourensia cernua,Flourensia cernua,Y,Y,SKME_036,EKB,"Plot 17, stake 33",681542.73,3535078.28,1317,S009015,
-2016,3,23,winter,dith wisl,Dithyrea wislinezi,Dithyrea wislinezi,Y,Y,SKME_037,EKB,"Plot 16, stake 17",681491.6,3535090.76,1319,S008867,
-2016,3,23,winter,lyci ande,Lycium torreyi,Lycium andersonii,Y,Y,SKME_038,EKB,"Plot 15, stake 76",681410.99,3535047.34,1320,S008875,
-2016,3,23,winter,pseu cane,Pseudognaphalium canescens,Pseudognaphalium canescens,Y,Y,SKME_039,EKB,"Plot 23, stake 74",681706.89,3535024.91,1315,S008877,
-2016,3,23,winter,oeno prim,Oenothera primiveris,Oenothera primiveris,N,Y,SKME_040,EKB,"Plot 9, stake 25",681414.21,3535166.8,1319,S008819,
-2016,3,23,winter,alli inca,Allionia incarnata,Allionia incarnata,Y,Y,SKME_041,EKB,"Plot 7, stake 53",681222.2,3535171.07,1322,S008886,
-2016,3,23,winter,ephe trif,Ephedra trifurca,Ephedra trifurca,Y,Y,SKME_042,EKB,ramada,681200.79,3535287.25,1315,S008865,
-2016,3,23,winter,ephe trif,Ephedra torreyana,Ephedra trifurca,Y,Y,SKME_043,EKB,ramada,681200.79,3535287.25,1315,S008882,
-2016,3,23,winter,yucc elat,Yucca elata,Yucca elata,Y,Y,SKME_044,EKB,"Plot 1, W side",681207.42,3535262.9,1321,S009047,
-2016,3,23,winter,rume hyme,Rumex hymenosepalus,Rumex hymenosepalus,Y,Y,SKME_045,EKB,"Plot 1, N side",681225.78,3535281.68,1321,S009000,
-2016,9,5,summer,acac greg,Acacia greggii,Mimosa aculeaticarpa,Y,Y,SKME_046,EKB,ramada,681200.79,3535287.25,1315,S008878,
-2016,9,5,summer,acac cons,Acacia constricta,Vachellia constricta,Y,Y,SKME_047,EKB,ramada,681200.79,3535287.25,1315,S008828,
-2016,9,5,summer,tide lanu,Tidestromia lanuginosa,Tidestromia lanuginosa,Y,Y,SKME_048,EKB,ramada,681200.79,3535287.25,1315,S009048,
-2016,9,5,summer,erag lehm,Eragrostis lehmanniana,Eragrostis lehmanniana,Y,Y,SKME_049,EKB,ramada,681200.79,3535287.25,1315,S008868,
-2016,9,5,summer,aris adsc,Aristida adscensionis,Aristida adscensionis,Y,Y,SKME_050,EKB,ramada,681200.79,3535287.25,1315,S008889,
-2016,9,5,summer,bout aris,Bouteloua aristidoides,Bouteloua aristidoides,Y,Y,SKME_051,EKB,ramada,681200.79,3535287.25,1315,S009008,
-2016,9,5,summer,ambr arte,Ambrosia artemisiifolia,Ambrosia artemisiifolia,Y,Y,SKME_052,EKB,ramada,681200.79,3535287.25,1315,S008858,
-2016,9,5,summer,boer torr,Boerhavia spicata,Boerhavia spicata,Y,Y,SKME_053,EKB,ramada,681200.79,3535287.25,1315,S008859,
-2016,9,5,summer,boer inte,Boerhavia intermedia,Boerhavia intermedia,Y,Y,SKME_054,EKB,ramada,681200.79,3535287.25,1315,S008898,
-2016,9,5,summer,zinn gran,Zinnia grandiflora,Zinnia grandiflora,Y,Y,SKME_055,EKB,ramada,681200.79,3535287.25,1315,S009009,
-2016,9,5,summer,amar palm,Amaranthus palmeri,Amaranthus palmeri,Y,Y,SKME_056,EKB,ramada,681200.79,3535287.25,1315,S008888,
-2016,9,5,summer,bout barb,Chondrosum barbatum,Bouteloua barbata,Y,Y,SKME_057,EKB,ramada,681200.79,3535287.25,1315,S008849,
-2016,9,5,summer,abut parv,Malvella lepidota,Abutilon parvulum,Y,Y,SKME_058,EKB,ramada,681200.79,3535287.25,1315,S009045,
-2016,9,5,summer,pani ariz,Brachiaria arizonica,Brachiaria arizonica,Y,Y,SKME_059,EKB,ramada,681200.79,3535287.25,1315,S009028,
-2016,9,5,summer,erio lemm,Eriochloa lemmonii,Eriochloa acuminata,Y,Y,SKME_060,EKB,ramada,681200.79,3535287.25,1315,S009035,
-2016,9,5,summer,muhl port,Muhlenbergia porteri,Muhlenbergia porteri,Y,Y,SKME_061,EKB,ramada,681200.79,3535287.25,1315,S009018,
-2016,9,5,summer,kall hirs,Kallstroemia hirsutissima,Kallstroemia hirsutissima,Y,Y,SKME_062,EKB,ramada,681200.79,3535287.25,1315,S008829,
-2016,9,5,summer,kall gran,Kallstroemia grandiflora,Kallstroemia grandiflora,Y,Y,SKME_063,EKB,ramada,681200.79,3535287.25,1315,S008848,
-2016,9,5,summer,tetr coul,Tetraclea coulteri,Clerodendrum coulteri,Y,Y,SKME_064,EKB,ramada,681200.79,3535287.25,1315,S009069,
-2016,9,5,summer,tali aura,Portulaca suffretescens,Talinum aurantiacum,Y,Y,SKME_065,EKB,ramada,681200.79,3535287.25,1315,S009029,
-2016,9,5,summer,cass lept,Chamaecrista nictitans,Chamaecrista nictitans,Y,Y,SKME_066,EKB,ramada,681200.79,3535287.25,1315,S009058,
-2016,9,5,summer,chlo virg,Chloris virgata,Chloris virgata,Y,Y,SKME_067,EKB,ramada,681200.79,3535287.25,1315,S008879,
-2016,9,5,summer,tria port,Trianthema portulacastrum,Trianthema portulacastrum,Y,Y,SKME_068,EKB,ramada,681200.79,3535287.25,1315,S009025,
-2016,9,5,summer,enne desv,Hilaria mutica,Enneapogon desvauxii,Y,Y,SKME_069,EKB,ramada,681200.79,3535287.25,1315,S008869,
-2016,9,5,summer,boer cocc,Boerhavia coccinea,Boerhavia coccinea,Y,Y,SKME_070,SDT,southern part of site,681576.522,3535025.384,1318,S009019,
-2016,9,5,summer,euph serp,Euphorbia micromera,Euphorbia serpillifolia,Y,Y,SKME_071,SDT,plot 21,681552.1,3535000.2,1318.13,S009068,
-2016,9,5,summer,poly twee,Polygala tweedyi,Polygala lindheimeri,Y,Y,SKME_072,EKB,ramada,681200.79,3535287.25,1315,S008839,
-2016,9,5,summer,ammo chen,Ammocodon chenopodioides,Ammocodon chenopodioides,Y,Y,SKME_073,EKB,ramada,681200.79,3535287.25,1315,S009059,
-2016,9,5,summer,sida proc,Sida abutifolia,Sida abutifolia,Y,Y,SKME_074,EKB,ramada,681200.79,3535287.25,1315,S008838,
-2016,9,5,summer,sida neom,Sida spinosa,Sida neomexicana,Y,Y,SKME_075,EKB,ramada,681200.79,3535287.25,1315,S008896,
-2016,9,5,summer,spha laxa,Sphaeralcea coulteri,Sphaeralcea laxa,Y,Y,SKME_076,EKB,ramada,681200.79,3535287.25,1315,S009049,
-2016,9,5,summer,cusc umbe,Cuscuta tuberculata,Cuscuta umbellata,Y,Y,SKME_077,EKB,plot 16,681473.49,3535071.07,1318.99,S008843,
-2016,9,5,summer,crot pumi,Crotalaria pumila,Crotalaria pumila,Y,Y,SKME_078,EKB,ramada,681200.79,3535287.25,1315,S008820,
-2016,9,5,summer,euph serp,Euphorbia serpyllifolia,Euphorbia serpyllifolia,Y,Y,SKME_079,EKB,ramada,681200.79,3535287.25,1315,S009038,
-2016,9,5,summer,hapl tenu,Isocoma tenuisectus,Isocoma tenuisectus,Y,Y,SKME_080,EKB,ramada,681200.79,3535287.25,1315,S009078,
-2016,9,5,summer,chen frem,Atriplex acanthocarpa,Chenopodium fremontii,Y,Y,SKME_081,EKB,ramada,681200.79,3535287.25,1315,S009039,
-2016,9,5,summer,euph serr,Euphorbia serrula,Euphorbia serrula,Y,Y,SKME_082,EKB,plot 7,681228.35,3535177.61,1321.95,S009024,
-2016,9,5,summer,trid pulc,Erioneuron pulchellum,Dasyochloa pulchella,Y,Y,SKME_083,EKB,ramada,681200.79,3535287.25,1315,S009056,
-2016,9,5,summer,xant spin ,Xanthisma spinulosum,Xanthisma spinulosum,Y,Y,SKME_084,EKB,ramada,681200.79,3535287.25,1315,S008831,
-2016,9,5,summer,sals kali,Kali tragus,Salsola tragus,Y,Y,SKME_085,EKB,ramada,681200.79,3535287.25,1315,S008852,
-2016,9,5,summer,bahi absi,Parthenium incanum,Bahia absinthifolia,Y,Y,SKME_086,EKB,ramada,681200.79,3535287.25,1315,S008853,
-2016,9,5,summer,pect papp,Pectis papposa,Pectis papposa,Y,Y,SKME_087,EKB,ramada,681200.79,3535287.25,1315,S008823,
-2016,9,7,summer,bout barb,Bouteloua gracilis,Bouteloua barbata,Y,Y,SKME_088,EKB,plot 21,681552.1,3535000.2,1318.13,S009079,
-2016,9,7,summer,kall cali,Kallstroemia californica,Kallstroemia californica,Y,Y,SKME_089,EKB,S of plot 12,681659.35,3535172.45,1314.7,S008840,
-2016,9,7,summer,ipom cost,Ipomoea costellata,Ipomoea costellata,Y,Y,SKME_090,EKB,"plot 16, stake 77",681492.66,3535053.56,1318.86,S008850,
-2016,9,7,summer,dale brac,Dalea brachystachya,Dalea brachystachys,Y,Y,SKME_091,EKB,"plot 16, stake 16",681485.38,3535090.46,1318.45,S008851,
-2016,9,7,summer,both barb,Bothriochloa barbinodis,Bothriochloa barbinodis,Y,Y,SKME_092,SDT,plot 8,681306.913,3535177.001,1320,S008842,
-2016,9,7,summer,aris tern,Aristida purpurea,Aristida ternipes,Y,Y,SKME_093,SDT,plot 11,681558.57,3535179.18,1316.43,S008841,
-2016,9,7,summer,comm erec,Commelina erecta,Commelina erecta,Y,Y,SKME_094,EKB,NE corner of plot 5,681551.663,3535304.086,1315,S008822,
-2016,9,7,summer,hapl grac,Machaeranthera gracilis,Machaeranthera gracilis,Y,Y,SKME_095,EKB,"plot 1, stake 53",681219.87,3535256.66,1321.57,S008830,
-2016,9,7,summer,carl line,Carlowrightia linearifolia,Carlowrightia linearifolia,Y,Y,SKME_096,EKB,SE of plot 1,681201.28,3535237.74,1322.36,S008821,
-2016,9,7,summer,apod undu,Apodanthera undulata,Apodanthera undulata,Y,Y,SKME_097,EKB,between plots 1 and 2,681251.07,3535288.52,1321.08,S009046,
-2016,9,7,summer,pani hirt,Panicum hirticaule,Panicum hirticaule,Y,Y,SKME_098,EKB,path between 6 and 12,681576.98,3535264.95,1315,S009036,
-2016,9,7,summer,spor cont,Sporobolus contractus,Sporobolus contractus,Y,Y,SKME_099,EKB,"plot 4, stake 17",681469.81,3535288.5,1317.31,S009034,
-2016,9,7,summer,bray dens,Guilleminea densa,Guilleminea densa,Y,Y,SKME_100,EKB,ramada,681200.79,3535287.25,1315,S009026,
-2016,9,7,summer,tali aura,Phemeranthus aurantiacus,Talinum aurantiacum,Y,Y,SKME_101,EKB,ramada,681200.79,3535287.25,1315,S008833,
-2016,9,7,summer,dale nana,Dalea nana,Dalea nana,Y,Y,SKME_102,EKB,"plot 3, stake 33",681368.99,3535273.54,1319.05,S008832,
-2016,9,7,summer,zinn pumi,Zinnia acerosa,Zinnia acerosa,Y,Y,SKME_103,EKB,plot 4,681451.19,3535268.98,1317.83,S009044,
-2016,9,7,summer,seta leuc,Setaria macrostachya,Setaria leucopila,Y,Y,SKME_104,EKB,NE corner of plot 4,681469.81,3535288.5,1317.31,S009055,
-2016,9,7,summer,enne desv,Enneapogon desvauxii,Enneapogon desvauxii,Y,Y,SKME_105,EKB,W of Plot 3,681357.08,3535260.79,1318,S009054,
-2017,3,29,winter,cryp cras,Cryptantha crassisepala,,Y,Y,SKME_106,EKB,far entrance,,,,S009984,
-2017,3,29,winter,cryp micr,Cryptantha micrantha,,Y,Y,SKME_107,EKB,far entrance,,,,S009993,
-2017,3,29,winter,plag ariz,Plagiobothrys arizonicus,,Y,Y,SKME_108,EKB,far entrance,,,,S009983,
-2017,3,29,winter,spha inca,Sphaeralcea inca,,Y,Y,SKME_109,GMY,SW corner of plot 18,,,,S009978,
-2017,3,29,winter,bahi absi,Bahia absinthifolia,,Y,Y,SKME_110,GMY,SE corner of plot 18,,,,S009972,
-2017,3,29,winter,astr allo,Astragalus allochorus,,Y,N,SKME_111,EKB,far entrance,,,,,
-2017,3,29,winter,pect recu,Pectocarya recurvata,,Y,Y,SKME_112,EKB,far entrance,,,,S009992,
-2017,3,29,winter,sisy irio,Sisymbrium irio,,Y,Y,SKME_113,EKB,far entrance,,,,S009995,
-2017,3,30,winter,hapl spin,Haplopappus spinulosus,,Y,Y,SKME_114,EKB,plot 22,,,,S009982,
-2017,3,30,winter,caly wrig,Calycoseris wrightii,,Y,Y,SKME_115,EKB,plot 22,,,,S009979,
-2017,3,30,winter,lina bige,Linanthus bigelovii,,Y,Y,SKME_116,EKB,plot 22,,,,S009989,
-2017,3,30,winter,gili mexi,Gilia mexicana,,Y,Y,SKME_117,EKB,plot 22,,,,S009998,
-2017,3,30,winter,erod texa,Erodium texanum,,Y,Y,SKME_118,EKB,"plot 21, stake 77",,,,S009977,
-2017,3,30,winter,lupi spar,Lupinus sparsiflorus,,Y,Y,SKME_119,EKB,"plot 20, stake 57",,,,S009974,
-2017,3,29,winter,chen sp,Chenopodium sp.,,Y,Y,SKME_120,GMY,unknown,,,,S009996,
-2017,3,31,winter,port suff,Portulaca suffretescens,,Y,Y,SKME_121,EKB ,plot 8,,,,S009976,
-2017,4,1,winter,astr nutt,Astragalus nuttallianus,,Y,Y,SKME_122,EKB,NE corner of plot 7,,,,S009991,
-2017,4,1,winter,plan sp,Plantago sp. ,,Y,Y,SKME_123,EKB ,plot 11,,,,S009973,
-2017,4,1,winter,cymo mult,Cymopterus multinervatus,,Y,Y,SKME_124,EKB,plot 10,,,,S009971,
-2017,3,30,winter,erig dive,Erigeron divergens,,Y,Y,SKME_125,EKB,plot 20,,,,S009999,
-2017,3,30,winter,atri acan,Atriplex acanthocarpa,,Y,Y,SKME_126,GMY,plot 15,,,,S009987,
-2017,4,1,winter,nama hisp,Nama hispidum,,Y,Y,SKME_127,EKB,far entrance,,,,S009988,
-2017,4,1,winter,laen coul,Laennecia coulteri,,Y,Y,SKME_128,EKB,"plot 11, stake 37",,,,S009990,
+"","year","month","day","season","sp_code","sci_name_fieldID","sci_name_profID","voucher","DNA","label_number","collector","location","easting","northing","elevation..m.","vial_barcode","notes","trnl_total","ITS_total"
+"1",2017,1,26,"","","","","","","millet","","",NA,NA,NA,"S009063","bait",NA,NA
+"2",2016,3,20,"winter","cass bauh","Cassia bauhinoides","Senna bauhinoides","Y","Y","SKME_001","EKB","ramada",681200.79,3535287.25,1315,"S009007","",16791,593
+"3",2016,3,20,"winter","spha hast","Sphaeralcea coccinea","Sphaeralcea hastulata","Y","Y","SKME_002","EKB","Plot 23, stake 65",681706.89,3535024.91,1315,"S009904","",NA,NA
+"4",2016,3,20,"winter","amsi tess","Amsinckia tessellata","Amsinckia tessellata","Y","Y","SKME_003","EKB","Plot 22, stake 67",681645.78,3534990.26,1316,"S009037","",25492,2979
+"5",2016,3,20,"winter","micr lene","Uropappus lindleyi","Uropappus lindleyi","Y","Y","SKME_004","EKB","Plot 22, stake 35",681631.8,3535006.72,1316,"S009099","",37951,599
+"6",2016,3,20,"winter","erig conc","Erigeron concinnus","Erigeron concinnus","Y","Y","SKME_005","EKB","Plot 22, stake 53",681620.44,3534994.09,1316,"S009016","",26611,5170
+"7",2016,3,20,"winter","atri cane","Atriplex canescens","Atriplex canescens","Y","Y","SKME_006","EKB","Plot 20, stake 31",681459.32,3534993.28,1319,"S008895","",27164,1011
+"8",2016,3,20,"winter","euro lana","Eurotia lanata","Krascheninnikovia lanata","Y","Y","SKME_007","EKB","Plot 13, stake 75",681254.99,3535039.18,1322,"S009001","",24517,1062
+"9",2016,3,20,"winter","pros glan","Prosopis glandulosa","Prosopis glandulosa","Y","Y","SKME_008","EKB","Plot 13, stake 72",681236.34,3535038.21,1322,"S009006","",40790,56
+"10",2016,3,20,"winter","phac ariz","Phacelia arizonica","Phacelia arizonica","Y","Y","SKME_009","EKB","ramada",681200.79,3535287.25,1315,"S008897","",22430,1827
+"11",2016,3,20,"winter","lupi conc","Lupinus concinnus","Lupinus concinnus","Y","Y","SKME_010","EKB","ramada",681200.79,3535287.25,1315,"S009017","",11758,4305
+"12",2016,3,20,"winter","chen frem","Chenopodium fremontii","Chenopodium fremontii","Y","Y","SKME_011","EKB","ramada",681200.79,3535287.25,1315,"S008870","",32049,36
+"13",2016,3,20,"winter","desc pinn","Descurainia pinnata","Descurainia pinnata","Y","Y","SKME_012","EKB","ramada",681200.79,3535287.25,1315,"S009010","",31011,5722
+"14",2016,3,20,"winter","guti saro","Gutierrezia sarothrae","Gutierrezia microcephala","Y","Y","SKME_013","EKB","ramada",681200.79,3535287.25,1315,"S009013","",36855,1141
+"15",2016,3,23,"winter","mala fend","Malacothrix fendleri","Malacothrix fendleri","Y","Y","SKME_014","SDT","ramada",681200.79,3535287.25,1315,"S009003","",42241,511
+"16",2016,3,23,"winter","plan purs","Plantago patagonica","Plantago patagonica","Y","Y","SKME_015","EKB","far entrance",681231.07,3535279.78,1315,"S009027","",18335,9773
+"17",2016,3,23,"winter","crot cory","Croton pottsii","Croton pottsii","Y","Y","SKME_016","EKB","far entrance",681231.07,3535279.78,1315,"S008809","",31654,8391
+"18",2016,3,23,"winter","erig conc","Erigeron divergens","Erigeron concinnus","Y","Y","SKME_017","EKB","Plot 1, stake 43",681219.91,3535262.79,1321,"S008885","",24635,1618
+"19",2016,3,23,"winter","erio aber","Eriogonum abertianum","Eriogonum abertianum","Y","Y","SKME_018","EKB","Plot 1, stake 13",681219.36,3535279.6,1321,"S008864","",31719,1498
+"20",2016,3,23,"winter","hoff dens","Hoffmanseggia densiflora","Hoffmannseggia glauca","Y","Y","SKME_019","SDT","Plot 1, stake 13",681219.89,3535281.58,1321,"S008818","",32715,9236
+"21",2016,3,23,"winter","lepi lasi","Lepidium lasiocarpum","Lepidium lasiocarpum","Y","Y","SKME_020","SDT","Plot 1, stake 17",681244.22,3535281.57,1321,"S009057","",26684,4979
+"22",2016,3,23,"winter","astr allo","Astragalus allochrous","Astragalus allochrous","Y","Y","SKME_021","EKB","Plot 2, stake 12",681288.65,3535283.03,1320,"S008874","",33546,3890
+"23",2016,3,23,"winter","chae stev","Chaenactis stevioides","Chaenactis stevioides","Y","Y","SKME_022","EKB","Plot 1",681225.98,3535262.99,1321,"S009098","",22091,3546
+"24",2016,3,23,"winter","erod cicu","Erodium cicutarium","Erodium cicutarium","Y","Y","SKME_023","EKB","Plot 1",681225.98,3535262.99,1321,"S009011","",34357,15
+"25",2016,3,23,"winter","pere nana","Perezia nana","Perezia nana","Y","Y","SKME_024","EKB","between Plots 2 and 3",681350,3535275,1320,"S009012","",27584,3675
+"26",2016,3,23,"winter","dich pulc","Dichelostemma pulchellum","Dichelostemma pulchellum","Y","Y","SKME_025","EKB","Plot 2, SE corner",681326.62,3535240.94,1320,"S008866","",35702,21
+"27",2016,3,23,"winter","sper echi","Spermolepis echinata","Spermolepis echinata","Y","Y","SKME_026","EKB","Plot 2, SW corner",681276.31,3535288.84,1320,"S009002","",22310,206
+"28",2016,3,23,"winter","lapp redo","Lappula redowskii","Lappula redowskii","Y","Y","SKME_027","SKME","Plot 2, N side",681301,3535283.44,1320,"S009089","",24590,1725
+"29",2016,3,23,"winter","lesq gord","Lesquerella gordonii","Physaria gordonii","Y","Y","SKME_028","SKME","Plot 3, stake 32",681363.26,3535273.13,1318,"S008887","",31353,6860
+"30",2016,3,23,"winter","esch mexi","Eschscholzia californica","Eschscholzia californica","Y","Y","SKME_029","SDT","W of Plot 3",681357.08,3535260.79,1318,"S009005","",21090,40
+"31",2016,3,23,"winter","dale pogo","Dalea pogonathera","Dalea pogonathera","Y","Y","SKME_030","EKB","Plot 3, stake 36",681387.98,3535274.16,1318,"S009088","",15104,159
+"32",2016,3,23,"winter","delp woot","Delphinium wootonii","Delphinium wootonii","N","Y","SKME_031","EKB","Plot 3, stake 31",681356.75,3535272.74,1318,"S008876","",29295,175
+"33",2016,3,23,"winter","bail mult","Baileya multiradiata","Baileya multiradiata","Y","Y","SKME_032","SDT","Plot 4, stake 51",681432.77,3535262.24,1317,"S008892","",34984,1740
+"34",2016,3,23,"winter","chae eric","Chaetopappa ericoides","Chaetopappa ericoides","Y","Y","SKME_033","SDT","Plot 6, stake 15",681608.23,3535310.21,1314,"S008880","",38177,5588
+"35",2016,3,23,"winter","eria diff","Eriastrum diffusum","Eriastrum diffusum","Y","Y","SKME_034","SDT","ramada",681200.79,3535287.25,1315,"S009014","",28481,3323
+"36",2016,3,23,"winter","sola elea","Solanum elaeagnifolium","Solanum elaeagnifolium","Y","Y","SKME_035","EKB","N of Plot 14",681323.33,3535080.38,1321,"S008893","",15619,3065
+"37",2016,3,23,"winter","flou cern","Flourensia cernua","Flourensia cernua","Y","Y","SKME_036","EKB","Plot 17, stake 33",681542.73,3535078.28,1317,"S009015","",19449,2161
+"38",2016,3,23,"winter","dith wisl","Dithyrea wislinezi","Dithyrea wislinezi","Y","Y","SKME_037","EKB","Plot 16, stake 17",681491.6,3535090.76,1319,"S008867","",25339,1752
+"39",2016,3,23,"winter","lyci ande","Lycium torreyi","Lycium andersonii","Y","Y","SKME_038","EKB","Plot 15, stake 76",681410.99,3535047.34,1320,"S008875","",20961,22
+"40",2016,3,23,"winter","pseu cane","Pseudognaphalium canescens","Pseudognaphalium canescens","Y","Y","SKME_039","EKB","Plot 23, stake 74",681706.89,3535024.91,1315,"S008877","",24640,2548
+"41",2016,3,23,"winter","oeno prim","Oenothera primiveris","Oenothera primiveris","N","Y","SKME_040","EKB","Plot 9, stake 25",681414.21,3535166.8,1319,"S008819","",17751,1493
+"42",2016,3,23,"winter","alli inca","Allionia incarnata","Allionia incarnata","Y","Y","SKME_041","EKB","Plot 7, stake 53",681222.2,3535171.07,1322,"S008886","",15497,565
+"43",2016,3,23,"winter","ephe trif","Ephedra trifurca","Ephedra trifurca","Y","Y","SKME_042","EKB","ramada",681200.79,3535287.25,1315,"S008865","",17988,556
+"44",2016,3,23,"winter","ephe trif","Ephedra torreyana","Ephedra trifurca","Y","Y","SKME_043","EKB","ramada",681200.79,3535287.25,1315,"S008882","",25472,1475
+"45",2016,3,23,"winter","yucc elat","Yucca elata","Yucca elata","Y","Y","SKME_044","EKB","Plot 1, W side",681207.42,3535262.9,1321,"S009047","",25991,644
+"46",2016,3,23,"winter","rume hyme","Rumex hymenosepalus","Rumex hymenosepalus","Y","Y","SKME_045","EKB","Plot 1, N side",681225.78,3535281.68,1321,"S009000","",21453,2935
+"47",2016,9,5,"summer","acac greg","Acacia greggii","Mimosa aculeaticarpa","Y","Y","SKME_046","EKB","ramada",681200.79,3535287.25,1315,"S008878","",21401,3326
+"48",2016,9,5,"summer","acac cons","Acacia constricta","Vachellia constricta","Y","Y","SKME_047","EKB","ramada",681200.79,3535287.25,1315,"S008828","",29912,2055
+"49",2016,9,5,"summer","tide lanu","Tidestromia lanuginosa","Tidestromia lanuginosa","Y","Y","SKME_048","EKB","ramada",681200.79,3535287.25,1315,"S009048","",17443,5409
+"50",2016,9,5,"summer","erag lehm","Eragrostis lehmanniana","Eragrostis lehmanniana","Y","Y","SKME_049","EKB","ramada",681200.79,3535287.25,1315,"S008868","",24960,6167
+"51",2016,9,5,"summer","aris adsc","Aristida adscensionis","Aristida adscensionis","Y","Y","SKME_050","EKB","ramada",681200.79,3535287.25,1315,"S008889","",31777,4330
+"52",2016,9,5,"summer","bout aris","Bouteloua aristidoides","Bouteloua aristidoides","Y","Y","SKME_051","EKB","ramada",681200.79,3535287.25,1315,"S009008","",17066,9865
+"53",2016,9,5,"summer","ambr arte","Ambrosia artemisiifolia","Ambrosia artemisiifolia","Y","Y","SKME_052","EKB","ramada",681200.79,3535287.25,1315,"S008858","",29196,1283
+"54",2016,9,5,"summer","boer torr","Boerhavia spicata","Boerhavia spicata","Y","Y","SKME_053","EKB","ramada",681200.79,3535287.25,1315,"S008859","",13781,107
+"55",2016,9,5,"summer","boer inte","Boerhavia intermedia","Boerhavia intermedia","Y","Y","SKME_054","EKB","ramada",681200.79,3535287.25,1315,"S008898","",19554,73
+"56",2016,9,5,"summer","zinn gran","Zinnia grandiflora","Zinnia grandiflora","Y","Y","SKME_055","EKB","ramada",681200.79,3535287.25,1315,"S009009","",20009,1999
+"57",2016,9,5,"summer","amar palm","Amaranthus palmeri","Amaranthus palmeri","Y","Y","SKME_056","EKB","ramada",681200.79,3535287.25,1315,"S008888","",35018,632
+"58",2016,9,5,"summer","bout barb","Chondrosum barbatum","Bouteloua barbata","Y","Y","SKME_057","EKB","ramada",681200.79,3535287.25,1315,"S008849","",11965,3740
+"59",2016,9,5,"summer","abut parv","Malvella lepidota","Abutilon parvulum","Y","Y","SKME_058","EKB","ramada",681200.79,3535287.25,1315,"S009045","",35221,32
+"60",2016,9,5,"summer","pani ariz","Brachiaria arizonica","Brachiaria arizonica","Y","Y","SKME_059","EKB","ramada",681200.79,3535287.25,1315,"S009028","",17272,1909
+"61",2016,9,5,"summer","erio lemm","Eriochloa lemmonii","Eriochloa acuminata","Y","Y","SKME_060","EKB","ramada",681200.79,3535287.25,1315,"S009035","",23770,239
+"62",2016,9,5,"summer","muhl port","Muhlenbergia porteri","Muhlenbergia porteri","Y","Y","SKME_061","EKB","ramada",681200.79,3535287.25,1315,"S009018","",19843,1159
+"63",2016,9,5,"summer","kall hirs","Kallstroemia hirsutissima","Kallstroemia hirsutissima","Y","Y","SKME_062","EKB","ramada",681200.79,3535287.25,1315,"S008829","",19545,1000
+"64",2016,9,5,"summer","kall gran","Kallstroemia grandiflora","Kallstroemia grandiflora","Y","Y","SKME_063","EKB","ramada",681200.79,3535287.25,1315,"S008848","",26891,5973
+"65",2016,9,5,"summer","tetr coul","Tetraclea coulteri","Clerodendrum coulteri","Y","Y","SKME_064","EKB","ramada",681200.79,3535287.25,1315,"S009069","",25750,2069
+"66",2016,9,5,"summer","tali aura","Portulaca suffretescens","Talinum aurantiacum","Y","Y","SKME_065","EKB","ramada",681200.79,3535287.25,1315,"S009029","",23417,4152
+"67",2016,9,5,"summer","cass lept","Chamaecrista nictitans","Chamaecrista nictitans","Y","Y","SKME_066","EKB","ramada",681200.79,3535287.25,1315,"S009058","",28350,3333
+"68",2016,9,5,"summer","chlo virg","Chloris virgata","Chloris virgata","Y","Y","SKME_067","EKB","ramada",681200.79,3535287.25,1315,"S008879","",30744,20
+"69",2016,9,5,"summer","tria port","Trianthema portulacastrum","Trianthema portulacastrum","Y","Y","SKME_068","EKB","ramada",681200.79,3535287.25,1315,"S009025","",32103,1662
+"70",2016,9,5,"summer","enne desv","Hilaria mutica","Enneapogon desvauxii","Y","Y","SKME_069","EKB","ramada",681200.79,3535287.25,1315,"S008869","",34457,2468
+"71",2016,9,5,"summer","boer cocc","Boerhavia coccinea","Boerhavia coccinea","Y","Y","SKME_070","SDT","southern part of site",681576.522,3535025.384,1318,"S009019","",10462,1453
+"72",2016,9,5,"summer","euph serp","Euphorbia micromera","Euphorbia serpillifolia","Y","Y","SKME_071","SDT","plot 21",681552.1,3535000.2,1318.13,"S009068","",19815,1428
+"73",2016,9,5,"summer","poly twee","Polygala tweedyi","Polygala lindheimeri","Y","Y","SKME_072","EKB","ramada",681200.79,3535287.25,1315,"S008839","",20780,315
+"74",2016,9,5,"summer","ammo chen","Ammocodon chenopodioides","Ammocodon chenopodioides","Y","Y","SKME_073","EKB","ramada",681200.79,3535287.25,1315,"S009059","",27861,252
+"75",2016,9,5,"summer","sida proc","Sida abutifolia","Sida abutifolia","Y","Y","SKME_074","EKB","ramada",681200.79,3535287.25,1315,"S008838","",36004,22
+"76",2016,9,5,"summer","sida neom","Sida spinosa","Sida neomexicana","Y","Y","SKME_075","EKB","ramada",681200.79,3535287.25,1315,"S008896","",31178,67
+"77",2016,9,5,"summer","spha laxa","Sphaeralcea coulteri","Sphaeralcea laxa","Y","Y","SKME_076","EKB","ramada",681200.79,3535287.25,1315,"S009049","",26501,480
+"78",2016,9,5,"summer","cusc umbe","Cuscuta tuberculata","Cuscuta umbellata","Y","Y","SKME_077","EKB","plot 16",681473.49,3535071.07,1318.99,"S008843","",35029,3166
+"79",2016,9,5,"summer","crot pumi","Crotalaria pumila","Crotalaria pumila","Y","Y","SKME_078","EKB","ramada",681200.79,3535287.25,1315,"S008820","",19480,4527
+"80",2016,9,5,"summer","euph serp","Euphorbia serpyllifolia","Euphorbia serpyllifolia","Y","Y","SKME_079","EKB","ramada",681200.79,3535287.25,1315,"S009038","",36004,9900
+"81",2016,9,5,"summer","hapl tenu","Isocoma tenuisectus","Isocoma tenuisectus","Y","Y","SKME_080","EKB","ramada",681200.79,3535287.25,1315,"S009078","",22515,2673
+"82",2016,9,5,"summer","chen frem","Atriplex acanthocarpa","Chenopodium fremontii","Y","Y","SKME_081","EKB","ramada",681200.79,3535287.25,1315,"S009039","",40570,30
+"83",2016,9,5,"summer","euph serr","Euphorbia serrula","Euphorbia serrula","Y","Y","SKME_082","EKB","plot 7",681228.35,3535177.61,1321.95,"S009024","",19769,2014
+"84",2016,9,5,"summer","trid pulc","Erioneuron pulchellum","Dasyochloa pulchella","Y","Y","SKME_083","EKB","ramada",681200.79,3535287.25,1315,"S009056","",22276,427
+"85",2016,9,5,"summer","xant spin ","Xanthisma spinulosum","Xanthisma spinulosum","Y","Y","SKME_084","EKB","ramada",681200.79,3535287.25,1315,"S008831","",33255,3375
+"86",2016,9,5,"summer","sals kali","Kali tragus","Salsola tragus","Y","Y","SKME_085","EKB","ramada",681200.79,3535287.25,1315,"S008852","",36889,4124
+"87",2016,9,5,"summer","bahi absi","Parthenium incanum","Bahia absinthifolia","Y","Y","SKME_086","EKB","ramada",681200.79,3535287.25,1315,"S008853","",31454,1152
+"88",2016,9,5,"summer","pect papp","Pectis papposa","Pectis papposa","Y","Y","SKME_087","EKB","ramada",681200.79,3535287.25,1315,"S008823","",24502,29
+"89",2016,9,7,"summer","bout barb","Bouteloua gracilis","Bouteloua barbata","Y","Y","SKME_088","EKB","plot 21",681552.1,3535000.2,1318.13,"S009079","",29774,2834
+"90",2016,9,7,"summer","kall cali","Kallstroemia californica","Kallstroemia californica","Y","Y","SKME_089","EKB","S of plot 12",681659.35,3535172.45,1314.7,"S008840","",19230,1255
+"91",2016,9,7,"summer","ipom cost","Ipomoea costellata","Ipomoea costellata","Y","Y","SKME_090","EKB","plot 16, stake 77",681492.66,3535053.56,1318.86,"S008850","",25055,770
+"92",2016,9,7,"summer","dale brac","Dalea brachystachya","Dalea brachystachys","Y","Y","SKME_091","EKB","plot 16, stake 16",681485.38,3535090.46,1318.45,"S008851","",24349,2039
+"93",2016,9,7,"summer","both barb","Bothriochloa barbinodis","Bothriochloa barbinodis","Y","Y","SKME_092","SDT","plot 8",681306.913,3535177.001,1320,"S008842","",28350,1314
+"94",2016,9,7,"summer","aris tern","Aristida purpurea","Aristida ternipes","Y","Y","SKME_093","SDT","plot 11",681558.57,3535179.18,1316.43,"S008841","",36222,2142
+"95",2016,9,7,"summer","comm erec","Commelina erecta","Commelina erecta","Y","Y","SKME_094","EKB","NE corner of plot 5",681551.663,3535304.086,1315,"S008822","",30742,123
+"96",2016,9,7,"summer","hapl grac","Machaeranthera gracilis","Machaeranthera gracilis","Y","Y","SKME_095","EKB","plot 1, stake 53",681219.87,3535256.66,1321.57,"S008830","",23449,4268
+"97",2016,9,7,"summer","carl line","Carlowrightia linearifolia","Carlowrightia linearifolia","Y","Y","SKME_096","EKB","SE of plot 1",681201.28,3535237.74,1322.36,"S008821","",23784,1333
+"98",2016,9,7,"summer","apod undu","Apodanthera undulata","Apodanthera undulata","Y","Y","SKME_097","EKB","between plots 1 and 2",681251.07,3535288.52,1321.08,"S009046","",2012,33
+"99",2016,9,7,"summer","pani hirt","Panicum hirticaule","Panicum hirticaule","Y","Y","SKME_098","EKB","path between 6 and 12",681576.98,3535264.95,1315,"S009036","",21899,6184
+"100",2016,9,7,"summer","spor cont","Sporobolus contractus","Sporobolus contractus","Y","Y","SKME_099","EKB","plot 4, stake 17",681469.81,3535288.5,1317.31,"S009034","",22426,167
+"101",2016,9,7,"summer","bray dens","Guilleminea densa","Guilleminea densa","Y","Y","SKME_100","EKB","ramada",681200.79,3535287.25,1315,"S009026","",41655,13412
+"102",2016,9,7,"summer","tali aura","Phemeranthus aurantiacus","Talinum aurantiacum","Y","Y","SKME_101","EKB","ramada",681200.79,3535287.25,1315,"S008833","",21291,593
+"103",2016,9,7,"summer","dale nana","Dalea nana","Dalea nana","Y","Y","SKME_102","EKB","plot 3, stake 33",681368.99,3535273.54,1319.05,"S008832","",13546,2321
+"104",2016,9,7,"summer","zinn pumi","Zinnia acerosa","Zinnia acerosa","Y","Y","SKME_103","EKB","plot 4",681451.19,3535268.98,1317.83,"S009044","",23610,1504
+"105",2016,9,7,"summer","seta leuc","Setaria macrostachya","Setaria leucopila","Y","Y","SKME_104","EKB","NE corner of plot 4",681469.81,3535288.5,1317.31,"S009055","",33649,135
+"106",2016,9,7,"summer","enne desv","Enneapogon desvauxii","Enneapogon desvauxii","Y","Y","SKME_105","EKB","W of Plot 3",681357.08,3535260.79,1318,"S009054","",1506,1629
+"107",2017,3,29,"winter","cryp cras","Cryptantha crassisepala","","Y","Y","SKME_106","EKB","far entrance",NA,NA,NA,"S009984","",11870,NA
+"108",2017,3,29,"winter","cryp micr","Cryptantha micrantha","","Y","Y","SKME_107","EKB","far entrance",NA,NA,NA,"S009993","",7782,NA
+"109",2017,3,29,"winter","plag ariz","Plagiobothrys arizonicus","","Y","Y","SKME_108","EKB","far entrance",NA,NA,NA,"S009983","",10496,NA
+"110",2017,3,29,"winter","spha inca","Sphaeralcea inca","","Y","Y","SKME_109","GMY","SW corner of plot 18",NA,NA,NA,"S009978","",15631,NA
+"111",2017,3,29,"winter","bahi absi","Bahia absinthifolia","","Y","Y","SKME_110","GMY","SE corner of plot 18",NA,NA,NA,"S009972","",12386,NA
+"112",2017,3,29,"winter","astr allo","Astragalus allochorus","","Y","N","SKME_111","EKB","far entrance",NA,NA,NA,"","",NA,NA
+"113",2017,3,29,"winter","pect recu","Pectocarya recurvata","","Y","Y","SKME_112","EKB","far entrance",NA,NA,NA,"S009992","",12645,NA
+"114",2017,3,29,"winter","sisy irio","Sisymbrium irio","","Y","Y","SKME_113","EKB","far entrance",NA,NA,NA,"S009995","",15462,NA
+"115",2017,3,30,"winter","hapl spin","Haplopappus spinulosus","","Y","Y","SKME_114","EKB","plot 22",NA,NA,NA,"S009982","",13290,NA
+"116",2017,3,30,"winter","caly wrig","Calycoseris wrightii","","Y","Y","SKME_115","EKB","plot 22",NA,NA,NA,"S009979","",101,NA
+"117",2017,3,30,"winter","lina bige","Linanthus bigelovii","","Y","Y","SKME_116","EKB","plot 22",NA,NA,NA,"S009989","",12600,NA
+"118",2017,3,30,"winter","gili mexi","Gilia mexicana","","Y","Y","SKME_117","EKB","plot 22",NA,NA,NA,"S009998","",20220,NA
+"119",2017,3,30,"winter","erod texa","Erodium texanum","","Y","Y","SKME_118","EKB","plot 21, stake 77",NA,NA,NA,"S009977","",28,NA
+"120",2017,3,30,"winter","lupi spar","Lupinus sparsiflorus","","Y","Y","SKME_119","EKB","plot 20, stake 57",NA,NA,NA,"S009974","",20863,NA
+"121",2017,3,29,"winter","chen sp","Chenopodium sp.","","Y","Y","SKME_120","GMY","unknown",NA,NA,NA,"S009996","",10710,NA
+"122",2017,3,31,"winter","port suff","Portulaca suffretescens","","Y","Y","SKME_121","EKB ","plot 8",NA,NA,NA,"S009976","",14362,NA
+"123",2017,4,1,"winter","astr nutt","Astragalus nuttallianus","","Y","Y","SKME_122","EKB","NE corner of plot 7",NA,NA,NA,"S009991","",32732,NA
+"124",2017,4,1,"winter","plan sp","Plantago sp. ","","Y","Y","SKME_123","EKB ","plot 11",NA,NA,NA,"S009973","",11549,NA
+"125",2017,4,1,"winter","cymo mult","Cymopterus multinervatus","","Y","Y","SKME_124","EKB","plot 10",NA,NA,NA,"S009971","",15859,NA
+"126",2017,3,30,"winter","erig dive","Erigeron divergens","","Y","Y","SKME_125","EKB","plot 20",NA,NA,NA,"S009999","",13219,NA
+"127",2017,3,30,"winter","atri acan","Atriplex acanthocarpa","","Y","Y","SKME_126","GMY","plot 15",NA,NA,NA,"S009987","",17125,NA
+"128",2017,4,1,"winter","nama hisp","Nama hispidum","","Y","Y","SKME_127","EKB","far entrance",NA,NA,NA,"S009988","",15267,NA
+"129",2017,4,1,"winter","laen coul","Laennecia coulteri","","Y","Y","SKME_128","EKB","plot 11, stake 37",NA,NA,NA,"S009990","",15266,NA

--- a/manage_voucher_read_data.R
+++ b/manage_voucher_read_data.R
@@ -1,0 +1,21 @@
+library(dplyr)
+# Takes data from ITS and TrnL voucher data files, calculates total
+# number of reads for each sample and adds that to the voucher collection file
+# Data comes from repo.
+
+add_all_voucher_readtotals = function(){
+### Checking current state of trnL collection files
+
+trnL_data = read.csv("./SequencedData/Plants/trnL_voucher_data.csv")
+ITS_data = read.csv("./SequencedData/Plants/weeTU_ITS_voucher_data.csv")
+collection = read.csv("./CollectionData/plant_voucher_collection.csv")
+
+# Add trnL total reads to collection file
+
+sample_trnL_reads = trnL_data %>% group_by(Sample) %>% summarise(trnl_total=sum(Reads))
+sample_ITS_reads = ITS_data %>% group_by(Sample) %>% summarise(ITS_total=sum(Reads))
+add_trnL_total = left_join(collection,sample_trnL_reads, by=c("vial_barcode" = "Sample"))
+add_ITS_total = left_join(add_trnL_total, sample_ITS_reads, by=c("vial_barcode" = "Sample"))
+write.csv(add_ITS_total, "./CollectionData/plant_voucher_collection.csv")
+}
+


### PR DESCRIPTION
this adds a function that can be called to calculate total trnL and ITS reads for each sample and add that information to the collection file. This commit also adds the updated voucher file.

This pull request will close #25 